### PR TITLE
⭕ Retry if Servers, SSH Keys, or Load Balancer creation returns 500 response

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
 TF_ACC=1
 BINARYLANE_API_TOKEN=
+
+# Uncomment to enable debug logging (will dump request bodies)
+# TF_LOG=DEBUG
+
+# Uncomment to disable the Go cache when testing, useful for flaky tests
+# GOCACHE=off

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,12 @@ jobs:
         env:
           TF_ACC: '1'
           BINARYLANE_API_TOKEN: ${{ secrets.BINARYLANE_API_TOKEN }}
+      - name: Run sweepers
+        if: failure()
+        run: go test -v  ./internal/provider/... -sweep=all
+        env:
+          TF_ACC: '1'
+          BINARYLANE_API_TOKEN: ${{ secrets.BINARYLANE_API_TOKEN }}
   # unit:
   #   name: Unit Tests
   #   runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,12 @@ eval export $(cat .env)
 go test -v ./internal/provider/...
 ```
 
+To run Sweepers:
+
+```sh
+go test -v  ./internal/provider/... -sweep=all
+```
+
 ### Update modules
 
 ```sh

--- a/internal/binarylane/client.go
+++ b/internal/binarylane/client.go
@@ -1,0 +1,49 @@
+package binarylane
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+func NewClientWithAuth(endpoint string, token string) (*ClientWithResponses, error) {
+	if token == "" {
+		return nil, errors.New("missing or empty value for the Binary Lane API " +
+			"token. Set the `api_token` value in the configuration or use the " +
+			"BINARYLANE_API_TOKEN environment variable. If either is already set, " +
+			"ensure the value is not empty")
+	}
+
+	auth, err := securityprovider.NewSecurityProviderBearerToken(token)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create API client with supplied API token: %w", err)
+	}
+
+	if endpoint == "" {
+		endpoint = "https://api.binarylane.com.au/v2"
+	}
+
+	client, err := NewClientWithResponses(
+		endpoint,
+		WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+			dump, err := httputil.DumpRequestOut(req, true)
+			if err != nil {
+				return err
+			}
+			tflog.Debug(ctx, fmt.Sprintf("%q\n", dump))
+			return nil
+		}),
+		WithRequestEditorFn(auth.Intercept), // include auth AFTER the request logger
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Binary Lane API client: %w", err)
+	}
+
+	return client, nil
+}

--- a/internal/provider/load_balancer_resource.go
+++ b/internal/provider/load_balancer_resource.go
@@ -128,27 +128,49 @@ func (r *loadBalancerResource) Create(ctx context.Context, req resource.CreateRe
 
 	tflog.Info(ctx, fmt.Sprintf("Creating Load Balancer: name=%s", data.Name.ValueString()))
 
-	lbResp, err := r.bc.client.PostLoadBalancersWithResponse(ctx, body)
-	if err != nil {
-		tflog.Info(ctx, fmt.Sprintf("Attempted to create new load balancer: request=%+v", body))
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("Error sending request to create load balancer: name=%s", data.Name.ValueString()),
-			err.Error(),
-		)
-		return
+	const maxRetries = 3
+	var lbResp binarylane.PostLoadBalancersResponse
+
+retryLoop:
+	for i := 0; i < maxRetries; i++ {
+		lbResp, err := r.bc.client.PostLoadBalancersWithResponse(ctx, body)
+		if err != nil {
+			tflog.Info(ctx, fmt.Sprintf("Attempted to create new load balancer: request=%+v", body))
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("Error sending request to create load balancer: name=%s", data.Name.ValueString()),
+				err.Error(),
+			)
+			return
+		}
+
+		switch lbResp.StatusCode() {
+
+		case http.StatusOK:
+			break retryLoop
+
+		case http.StatusInternalServerError:
+			if i < maxRetries-1 {
+				tflog.Warn(ctx, "Received 500 creating load balancer, retrying...")
+				time.Sleep(time.Second * 5)
+				continue
+			}
+
+		default:
+			tflog.Info(ctx, fmt.Sprintf("Attempted to create new load balancer: request=%+v", body))
+			resp.Diagnostics.AddError(
+				"Unexpected HTTP status code creating load balancer",
+				fmt.Sprintf("Received %s creating new load balancer: name=%s. Details: %s", lbResp.Status(), data.Name.ValueString(), lbResp.Body),
+			)
+			return
+		}
 	}
 
+	// Check if retries exceeded
 	if lbResp.StatusCode() != http.StatusOK {
-		tflog.Info(ctx, fmt.Sprintf("Attempted to create new load balancer: request=%+v", body))
 		resp.Diagnostics.AddError(
-			"Unexpected HTTP status code creating load balancer",
-			fmt.Sprintf("Received %s creating new load balancer: name=%s. Details: %s", lbResp.Status(), data.Name.ValueString(), lbResp.Body))
-		return
-	}
-
-	diags = SetLoadBalancerModelState(ctx, &data.LoadBalancerModel, lbResp.JSON200.LoadBalancer)
-	resp.Diagnostics.Append(diags...)
-	if diags.HasError() {
+			"Failed to create load balancer after retries",
+			fmt.Sprintf("Final status code: %d", lbResp.StatusCode()),
+		)
 		return
 	}
 

--- a/internal/provider/load_balancer_resource.go
+++ b/internal/provider/load_balancer_resource.go
@@ -129,11 +129,12 @@ func (r *loadBalancerResource) Create(ctx context.Context, req resource.CreateRe
 	tflog.Info(ctx, fmt.Sprintf("Creating Load Balancer: name=%s", data.Name.ValueString()))
 
 	const maxRetries = 3
-	var lbResp binarylane.PostLoadBalancersResponse
+	var lbResp *binarylane.PostLoadBalancersResponse
 
 retryLoop:
 	for i := 0; i < maxRetries; i++ {
-		lbResp, err := r.bc.client.PostLoadBalancersWithResponse(ctx, body)
+		var err error
+		lbResp, err = r.bc.client.PostLoadBalancersWithResponse(ctx, body)
 		if err != nil {
 			tflog.Info(ctx, fmt.Sprintf("Attempted to create new load balancer: request=%+v", body))
 			resp.Diagnostics.AddError(
@@ -173,6 +174,8 @@ retryLoop:
 		)
 		return
 	}
+
+	data.Id = types.Int64Value(*lbResp.JSON200.LoadBalancer.Id)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/load_balancer_resource_test.go
+++ b/internal/provider/load_balancer_resource_test.go
@@ -140,8 +140,8 @@ func init() {
 						if err != nil {
 							return fmt.Errorf("Error deleting load balancer %d for test sweep: %w", *lb.Id, err)
 						}
-						if lbResp.StatusCode() != http.StatusOK {
-							return fmt.Errorf("Unexpected status deleting load balancer %d in test sweep: %s", *lb.Id, lbResp.Body)
+						if lbResp.StatusCode() != http.StatusNoContent {
+							return fmt.Errorf("Unexpected status %d deleting load balancer %d in test sweep: %s", lbResp.StatusCode(), *lb.Id, lbResp.Body)
 						}
 						log.Println("Deleted load balancer during test sweep:", *lb.Id)
 					}

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -255,21 +255,50 @@ func (r *serverResource) Create(ctx context.Context, req resource.CreateRequest,
 		data.Password = types.StringNull()
 	} else {
 		body.Password = data.Password.ValueStringPointer()
+		ctx = tflog.MaskMessageStrings(ctx, data.Password.String())
 	}
 
-	serverResp, err := r.bc.client.PostServersWithResponse(ctx, body)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("Error creating server: name=%s", data.Name.ValueString()),
-			err.Error(),
-		)
-		return
+	const maxRetries = 3
+	var serverResp binarylane.PostServersResponse
+
+retryLoop:
+	for i := 0; i < maxRetries; i++ {
+		serverResp, err := r.bc.client.PostServersWithResponse(ctx, body)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("Error creating server: name=%s", data.Name.ValueString()),
+				err.Error(),
+			)
+			return
+		}
+
+		switch serverResp.StatusCode() {
+
+		case http.StatusOK:
+			break retryLoop
+
+		case http.StatusInternalServerError:
+			if i < maxRetries-1 {
+				tflog.Warn(ctx, "Received 500 creating server, retrying...")
+				time.Sleep(time.Second * 5)
+				continue
+			}
+
+		default:
+			resp.Diagnostics.AddError(
+				"Unexpected HTTP status code creating server",
+				fmt.Sprintf("Received %s creating new server: name=%s. Details: %s", serverResp.Status(), data.Name.ValueString(), serverResp.Body),
+			)
+			return
+		}
 	}
 
+	// Check if retries exceeded
 	if serverResp.StatusCode() != http.StatusOK {
 		resp.Diagnostics.AddError(
-			"Unexpected HTTP status code creating server",
-			fmt.Sprintf("Received %s creating new server: name=%s. Details: %s", serverResp.Status(), data.Name.ValueString(), serverResp.Body))
+			"Failed to create server after retries",
+			fmt.Sprintf("Final status code: %d", serverResp.StatusCode()),
+		)
 		return
 	}
 

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -259,11 +259,12 @@ func (r *serverResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	const maxRetries = 3
-	var serverResp binarylane.PostServersResponse
+	var serverResp *binarylane.PostServersResponse
 
 retryLoop:
 	for i := 0; i < maxRetries; i++ {
-		serverResp, err := r.bc.client.PostServersWithResponse(ctx, body)
+		var err error
+		serverResp, err = r.bc.client.PostServersWithResponse(ctx, body)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Error creating server: name=%s", data.Name.ValueString()),

--- a/internal/provider/server_resource_test.go
+++ b/internal/provider/server_resource_test.go
@@ -119,8 +119,7 @@ echo "Hello World" > /var/tmp/output.txt
 
 func init() {
 	resource.AddTestSweepers("server", &resource.Sweeper{
-		Name:         "server",
-		Dependencies: []string{},
+		Name: "server",
 		F: func(_ string) error {
 			endpoint := os.Getenv("BINARYLANE_API_ENDPOINT")
 			if endpoint == "" {
@@ -161,12 +160,17 @@ func init() {
 				servers := *serverResp.JSON200.Servers
 				for _, s := range servers {
 					if strings.HasPrefix(*s.Name, "tf-test-") {
-						serverResp, err := client.DeleteLoadBalancersLoadBalancerIdWithResponse(ctx, *s.Id)
+						reason := "Terraform deletion"
+						params := binarylane.DeleteServersServerIdParams{
+							Reason: &reason,
+						}
+
+						serverResp, err := client.DeleteServersServerIdWithResponse(ctx, *s.Id, &params)
 						if err != nil {
 							return fmt.Errorf("Error deleting server %d during test sweep: %w", *s.Id, err)
 						}
-						if serverResp.StatusCode() != http.StatusOK {
-							return fmt.Errorf("Unexpected status deleting server %d in test sweep: %s", *s.Id, serverResp.Body)
+						if serverResp.StatusCode() != http.StatusNoContent {
+							return fmt.Errorf("Unexpected status %d deleting server %d in test sweep: %s", serverResp.StatusCode(), *s.Id, serverResp.Body)
 						}
 						log.Println("Deleted server during test sweep:", *s.Id)
 					}

--- a/internal/provider/ssh_key_resource.go
+++ b/internal/provider/ssh_key_resource.go
@@ -106,11 +106,12 @@ func (r *sshKeyResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	// Create API call logic
 	const maxRetries = 3
-	var sshResp binarylane.PostAccountKeysResponse
+	var sshResp *binarylane.PostAccountKeysResponse
 
 retryLoop:
 	for i := 0; i < maxRetries; i++ {
-		sshResp, err := r.bc.client.PostAccountKeysWithResponse(ctx, binarylane.SshKeyRequest{
+		var err error
+		sshResp, err = r.bc.client.PostAccountKeysWithResponse(ctx, binarylane.SshKeyRequest{
 			Name:      data.Name.ValueString(),
 			Default:   data.Default.ValueBoolPointer(),
 			PublicKey: data.PublicKey.ValueString(),

--- a/internal/provider/ssh_key_resource.go
+++ b/internal/provider/ssh_key_resource.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"terraform-provider-binarylane/internal/binarylane"
 	"terraform-provider-binarylane/internal/resources"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -15,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -103,22 +105,50 @@ func (r *sshKeyResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	// Create API call logic
-	sshResp, err := r.bc.client.PostAccountKeysWithResponse(ctx, binarylane.SshKeyRequest{
-		Name:      data.Name.ValueString(),
-		Default:   data.Default.ValueBoolPointer(),
-		PublicKey: data.PublicKey.ValueString(),
-	})
-	if err != nil {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("Error creating SSH Key: name=%s", data.Name.ValueString()),
-			err.Error(),
-		)
-		return
+	const maxRetries = 3
+	var sshResp binarylane.PostAccountKeysResponse
+
+retryLoop:
+	for i := 0; i < maxRetries; i++ {
+		sshResp, err := r.bc.client.PostAccountKeysWithResponse(ctx, binarylane.SshKeyRequest{
+			Name:      data.Name.ValueString(),
+			Default:   data.Default.ValueBoolPointer(),
+			PublicKey: data.PublicKey.ValueString(),
+		})
+		if err != nil {
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("Error creating SSH Key: name=%s", data.Name.ValueString()),
+				err.Error(),
+			)
+			return
+		}
+
+		switch sshResp.StatusCode() {
+
+		case http.StatusOK:
+			break retryLoop
+
+		case http.StatusInternalServerError:
+			if i < maxRetries-1 {
+				tflog.Warn(ctx, "Received 500 creating SSH key, retrying...")
+				time.Sleep(time.Second * 5)
+				continue
+			}
+
+		default:
+			resp.Diagnostics.AddError(
+				"Unexpected HTTP status code creating SSH key",
+				fmt.Sprintf("Received %s creating SSH key: name=%s. Details: %s", sshResp.Status(), data.Name.ValueString(), sshResp.Body),
+			)
+			return
+		}
 	}
+
+	// Check if retries exceeded
 	if sshResp.StatusCode() != http.StatusOK {
 		resp.Diagnostics.AddError(
-			"Unexpected HTTP status code creating new SSH key",
-			fmt.Sprintf("Received %s creating new SSH key: name=%s. Details: %s", sshResp.Status(), data.Name.ValueString(), sshResp.Body),
+			"Failed to create SSH key after retries",
+			fmt.Sprintf("Final status code: %d", sshResp.StatusCode()),
 		)
 		return
 	}

--- a/internal/provider/ssh_key_resource_test.go
+++ b/internal/provider/ssh_key_resource_test.go
@@ -1,9 +1,15 @@
 package provider
 
 import (
+	"context"
 	"crypto/ed25519"
 	"encoding/base64"
 	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"terraform-provider-binarylane/internal/binarylane"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -20,7 +26,7 @@ func TestSshKeyResource(t *testing.T) {
 			{
 				Config: providerConfig + `
 resource "binarylane_ssh_key" "test" {
-	name       = "tf_ssh_key_resource_test"
+	name       = "tf-test-key-resource-test"
 	public_key = "` + publicKey + `"
 }
 
@@ -32,13 +38,13 @@ data "binarylane_ssh_key" "test" {
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify resource values
-					resource.TestCheckResourceAttr("binarylane_ssh_key.test", "name", "tf_ssh_key_resource_test"),
+					resource.TestCheckResourceAttr("binarylane_ssh_key.test", "name", "tf-test-key-resource-test"),
 					resource.TestCheckResourceAttr("binarylane_ssh_key.test", "public_key", publicKey),
 					resource.TestCheckResourceAttr("binarylane_ssh_key.test", "default", "false"),
 					resource.TestCheckResourceAttrSet("binarylane_ssh_key.test", "id"),
 
 					// Verify data source values
-					resource.TestCheckResourceAttr("data.binarylane_ssh_key.test", "name", "tf_ssh_key_resource_test"),
+					resource.TestCheckResourceAttr("data.binarylane_ssh_key.test", "name", "tf-test-key-resource-test"),
 					resource.TestCheckResourceAttrSet("data.binarylane_ssh_key.test", "public_key"), // Ideally would check this is identical, but whitespace is not preserved
 					resource.TestCheckResourceAttr("data.binarylane_ssh_key.test", "default", "false"),
 					resource.TestCheckResourceAttrSet("data.binarylane_ssh_key.test", "id"),
@@ -62,14 +68,14 @@ data "binarylane_ssh_key" "test" {
 			// 			{
 			// 				Config: providerConfig + `
 			// resource "binarylane_ssh_key" "test" {
-			// 	name       = "tf_ssh_key_resource_test"
+			// 	name       = "tf-test-key-resource-test"
 			// 	public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJCsuosklP0T4fJcQDgkeVh7dQu+eV+vev1CfwdUkj7h test@company.internal"
 			// 	default    = true
 			// }
 			// 			`,
 			// 				Check: resource.ComposeAggregateTestCheckFunc(
 			// 					// Verify resource values
-			// 					resource.TestCheckResourceAttr("binarylane_ssh_key.test", "name", "tf_ssh_key_resource_test"),
+			// 					resource.TestCheckResourceAttr("binarylane_ssh_key.test", "name", "tf-test-key-resource-test"),
 			// 					resource.TestCheckResourceAttr("data.binarylane_ssh_key.test", "default", "true"),
 			// 				),
 			// 			},
@@ -105,4 +111,71 @@ func ImportByFingerprint(state *terraform.State) (fingerprint string, err error)
 	}
 
 	return rawState["fingerprint"], nil
+}
+
+func init() {
+	resource.AddTestSweepers("ssh_key", &resource.Sweeper{
+		Name: "ssh_key",
+		F: func(_ string) error {
+			endpoint := os.Getenv("BINARYLANE_API_ENDPOINT")
+			if endpoint == "" {
+				endpoint = "https://api.binarylane.com.au/v2"
+			}
+			token := os.Getenv("BINARYLANE_API_TOKEN")
+
+			client, err := binarylane.NewClientWithAuth(
+				endpoint,
+				token,
+			)
+
+			if err != nil {
+				return fmt.Errorf("Error creating Binary Lane API client: %w", err)
+			}
+
+			ctx := context.Background()
+
+			var page int32 = 1
+			perPage := int32(200)
+			nextPage := true
+
+			for nextPage {
+				params := binarylane.GetAccountKeysParams{
+					Page:    &page,
+					PerPage: &perPage,
+				}
+
+				keyResp, err := client.GetAccountKeysWithResponse(ctx, &params)
+				if err != nil {
+					return fmt.Errorf("Error getting SSH keys for test sweep: %w", err)
+				}
+
+				if keyResp.StatusCode() != http.StatusOK {
+					return fmt.Errorf("Unexpected status code getting SSH keys for test sweep: %s", keyResp.Body)
+				}
+
+				keys := keyResp.JSON200.SshKeys
+				for _, k := range keys {
+					if strings.HasPrefix(*k.Name, "tf-test-") {
+
+						keyResp, err := client.DeleteAccountKeysKeyIdWithResponse(ctx, int(*k.Id))
+						if err != nil {
+							return fmt.Errorf("Error deleting SSH key %d for test sweep: %w", *k.Id, err)
+						}
+						if keyResp.StatusCode() != http.StatusNoContent {
+							return fmt.Errorf("Unexpected status %d deleting SSH key %d for test sweep: %s", keyResp.StatusCode(), *k.Id, keyResp.Body)
+						}
+						log.Println("Deleted SSH key for test sweep:", *k.Id)
+					}
+				}
+				if keyResp.JSON200.Links == nil || keyResp.JSON200.Links.Pages == nil || keyResp.JSON200.Links.Pages.Next == nil {
+					nextPage = false
+					break
+				}
+
+				page++
+			}
+
+			return nil
+		},
+	})
 }

--- a/internal/provider/sweeper_test.go
+++ b/internal/provider/sweeper_test.go
@@ -1,0 +1,11 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}


### PR DESCRIPTION
This is a workaround for an issue with the create endpoints - sometimes they return a 500 response. See #13 

Explanation from BL:

>  I've reviewed the logs and it's a problem on our side when a user hits the API quickly after a period of inactivity. Actual fix is simple, but deploying it won't be trivial, so can't be sure where it will fit into the pipeline of new stuff.

This change also adds test sweepers, to clean up any lingering resources that are left around when the test suite breaks.