### PR TITLE
📠 Make `public_ipv4_count` a mandatory attribute on the server resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # terraform-provider-binarylane
 
-See the examples in the [examples directory](./examples/README.md).
+See the [documentation on the Terraform Registry](https://registry.terraform.io/providers/oscarhermoso/binarylane/latest), or see [examples in the `examples` directory](./examples/README.md).
 
 ```terraform
 resource "binarylane_server" "example" {
-  region = "per"
-  image  = "ubuntu-24.04"
-  size   = "std-min"
+  region            = "per"
+  image             = "ubuntu-24.04"
+  size              = "std-min"
+  public_ipv4_count = 1
 }
 ```
 

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -18,6 +18,7 @@ Provides a Binary Lane Server resource. This can be used to create and delete se
 ### Required
 
 - `image` (String) The slug of the selected operating system.
+- `public_ipv4_count` (Number) The number of public IPv4 addresses to assign to the server. If this is not provided, the server will be created with the default number of public IPv4 addresses.
 - `region` (String) The slug of the selected region.
 - `size` (String) The slug of the selected size.
 
@@ -27,7 +28,6 @@ Provides a Binary Lane Server resource. This can be used to create and delete se
 - `name` (String) The hostname of your server, such as vps01.yourcompany.com. If not provided, the server will be created with a random name.
 - `password` (String, Sensitive) If this is provided the specified or default remote user's account password will be set to this value. Only valid if the server supports password change actions. If omitted and the server supports password change actions a random password will be generated and emailed to the account email address.
 - `port_blocking` (Boolean) Port blocking of outgoing connections for email, SSH and Remote Desktop (TCP ports 22, 25, and 3389) is enabled by default for all new servers. If this is false port blocking will be disabled. Disabling port blocking is only available to reviewed accounts.
-- `public_ipv4_count` (Number) The number of public IPv4 addresses to assign to the server. If this is not provided, the server will be created with the default number of public IPv4 addresses.
 - `ssh_keys` (List of Number) This is a list of SSH key ids. If this is null or not provided, any SSH keys that have been marked as default will be deployed (assuming the operating system supports SSH Keys). Submit an empty list to disable deployment of default keys.
 - `user_data` (String) If provided this will be used to initialise the new server. This must be left null if the Image does not support UserData, see DistributionInfo.Features for more information.
 - `vpc_id` (Number) Leave null to use default (public) network for the selected region.

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -11,10 +11,10 @@ provider "binarylane" {
 }
 
 resource "binarylane_server" "example" {
-  name   = "tf-example-basic"
-  region = "per" # or "syd", "mel", "bne", "sin"
-  image  = "ubuntu-24.04"
-  size   = "std-min" # 1 VPCU, 1 GB Memory,  20 GB NVME Storage, 1000 GB Data Transfer
-
+  name              = "tf-example-basic"
+  region            = "per" # or "syd", "mel", "bne", "sin"
+  image             = "ubuntu-24.04"
+  size              = "std-min" # 1 VPCU, 1 GB Memory,  20 GB NVME Storage, 1000 GB Data Transfer
+  public_ipv4_count = 1
   # Password will be generated automatically and mailed to the account holder
 }

--- a/examples/cloud-init/main.tf
+++ b/examples/cloud-init/main.tf
@@ -9,10 +9,11 @@ terraform {
 provider "binarylane" {}
 
 resource "binarylane_server" "example" {
-  name            = "tf-cloud-init-example"
-  region          = "per"
-  image           = "ubuntu-24.04"
-  size            = "std-min"
-  user_data       = file("./cloud-config.yml")
-  wait_for_create = 300 # 5 mins
+  name              = "tf-cloud-init-example"
+  region            = "per"
+  image             = "ubuntu-24.04"
+  size              = "std-min"
+  user_data         = file("./cloud-config.yml")
+  wait_for_create   = 300 # 5 mins
+  public_ipv4_count = 1
 }

--- a/internal/provider/load_balancer_resource_test.go
+++ b/internal/provider/load_balancer_resource_test.go
@@ -32,25 +32,26 @@ func TestLoadBalancerResource(t *testing.T) {
 			{
 				Config: providerConfig + `
 resource "binarylane_server" "test" {
-	count  = 2
-	name   = "tf-test-lb-server-${count.index}"
-  region = "per"
-  image  = "debian-12"
-  size   = "std-min"
-	password = "` + password + `"
-	wait_for_create = 60
+  count             = 2
+  name              = "tf-test-lb-server-${count.index}"
+  region            = "per"
+  image             = "debian-12"
+  size              = "std-min"
+  password          = "` + password + `"
+  wait_for_create   = 60
+  public_ipv4_count = 1
 }
 
 resource "binarylane_load_balancer" "test" {
-	name   = "tf-test-lb"
-	server_ids = [binarylane_server.test.0.id, binarylane_server.test.1.id]
-	forwarding_rules = [{ entry_protocol = "http" }]
+  name             = "tf-test-lb"
+  server_ids       = [binarylane_server.test.0.id, binarylane_server.test.1.id]
+  forwarding_rules = [{ entry_protocol = "http" }]
 }
 
 data "binarylane_load_balancer" "test" {
   depends_on = [binarylane_load_balancer.test]
 
-	id = binarylane_load_balancer.test.id
+  id = binarylane_load_balancer.test.id
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -11,6 +11,9 @@ provider "binarylane" {
   # api_token = "test123"
 	# api_endpoint = "https://test.binarylane.internal.au/v2"
 }
+
+# End of provider config
+
 `
 )
 

--- a/internal/provider/server_firewall_rules_resource_test.go
+++ b/internal/provider/server_firewall_rules_resource_test.go
@@ -21,27 +21,29 @@ func TestServerFirewallRulesResource(t *testing.T) {
 			// Create and Read testing
 			{
 				Config: providerConfig + `
+
 resource "binarylane_server" "test" {
-	name   = "tf-test-server-fw-rules"
-  region = "per"
-  image  = "debian-12"
-  size   = "std-min"
-	password = "` + password + `"
-	wait_for_create = 60  # Must wait for the server to be ready before creating firewall rules
+  name              = "tf-test-server-fw-rules"
+  region            = "per"
+  image             = "debian-12"
+  size              = "std-min"
+  password          = "` + password + `"
+  wait_for_create   = 60 # Must wait for the server to be ready before creating firewall rules
+  public_ipv4_count = 0
 }
 
 resource "binarylane_server_firewall_rules" "test" {
   server_id = binarylane_server.test.id
-	firewall_rules = [
-		{
-			description = "Allow SSH"
-			protocol = "tcp"
-			source_addresses = ["0.0.0.0/0"]
-			destination_addresses = [binarylane_server.test.private_ipv4_addresses.0]
-			destination_ports = ["22"]
-			action = "accept"
-		}
-	]
+  firewall_rules = [
+    {
+      description           = "Allow SSH"
+      protocol              = "tcp"
+      source_addresses      = ["0.0.0.0/0"]
+      destination_addresses = [binarylane_server.test.private_ipv4_addresses.0]
+      destination_ports     = ["22"]
+      action                = "accept"
+    }
+  ]
 }
 
 data "binarylane_server_firewall_rules" "test" {
@@ -95,27 +97,29 @@ data "binarylane_server_firewall_rules" "test" {
 			// Update and Read testing
 			{
 				Config: providerConfig + `
+
 resource "binarylane_server" "test" {
-	name   = "tf-test-server-fw-rules"
-  region = "per"
-  image  = "debian-12"
-  size   = "std-min"
-	password = "` + password + `"
-	wait_for_create = 60  # Must wait for the server to be ready before creating firewall rules
+  name              = "tf-test-server-fw-rules"
+  region            = "per"
+  image             = "debian-12"
+  size              = "std-min"
+  password          = "` + password + `"
+  wait_for_create   = 60 # Must wait for the server to be ready before creating firewall rules
+  public_ipv4_count = 0
 }
 
 resource "binarylane_server_firewall_rules" "test" {
   server_id = binarylane_server.test.id
-	firewall_rules = [
-		{
-			description = "Allow HTTP" # Updated description
-			protocol = "tcp"
-			source_addresses = ["0.0.0.0/0"]
-			destination_addresses = [binarylane_server.test.private_ipv4_addresses.0]
-			destination_ports = ["80"] # Updated port
-			action = "accept"
-		},
-	]
+  firewall_rules = [
+    {
+      description           = "Allow HTTP" # Updated description
+      protocol              = "tcp"
+      source_addresses      = ["0.0.0.0/0"]
+      destination_addresses = [binarylane_server.test.private_ipv4_addresses.0]
+      destination_ports     = ["80"] # Updated port
+      action                = "accept"
+    },
+  ]
 }
 	`,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/provider/server_resource.go
+++ b/internal/provider/server_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -171,9 +170,10 @@ func (r *serverResource) Schema(ctx context.Context, _ resource.SchemaRequest, r
 	resp.Schema.Attributes["public_ipv4_count"] = &schema.Int32Attribute{
 		Description:         publicIpv4CountDescription,
 		MarkdownDescription: publicIpv4CountDescription,
-		Optional:            true,
-		Computed:            true,
-		Default:             int32default.StaticInt32(1),
+		Required:            true,
+		Optional:            false,
+		Computed:            false,
+		// Default:             int32default.StaticInt32(0), // TODO: Uncomment with 1.0 release (see issue #30)
 		Validators: []validator.Int32{
 			int32validator.AtLeast(0),
 		},

--- a/internal/provider/server_resource_test.go
+++ b/internal/provider/server_resource_test.go
@@ -31,9 +31,10 @@ func TestServerResource(t *testing.T) {
 			// Create and Read testing
 			{
 				Config: providerConfig + `
+
 resource "binarylane_vpc" "test" {
-	name     = "tf-test-server-resource"
-	ip_range = "10.240.0.0/16"
+  name     = "tf-test-server-resource"
+  ip_range = "10.240.0.0/16"
 }
 
 resource "binarylane_ssh_key" "test" {
@@ -49,24 +50,24 @@ resource "binarylane_ssh_key" "unused" {
 }
 
 resource "binarylane_server" "test" {
-	name   = "tf-test-server-resource"
-  region = "per"
-  image  = "debian-12"
-  size   = "std-min"
-	password = "` + password + `"
-	vpc_id = binarylane_vpc.test.id
-	public_ipv4_count = 0
-	user_data = <<EOT
+  name              = "tf-test-server-resource"
+  region            = "per"
+  image             = "debian-12"
+  size              = "std-min"
+  password          = "` + password + `"
+  vpc_id            = binarylane_vpc.test.id
+  public_ipv4_count = 0
+  ssh_keys          = [binarylane_ssh_key.test.id]
+  user_data         = <<EOT
 #cloud-config
 echo "Hello World" > /var/tmp/output.txt
 EOT
-	ssh_keys = [binarylane_ssh_key.test.id]
 }
 
 data "binarylane_server" "test" {
   depends_on = [binarylane_server.test]
 
-	id = binarylane_server.test.id
+  id = binarylane_server.test.id
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/provider/ssh_key_resource_test.go
+++ b/internal/provider/ssh_key_resource_test.go
@@ -25,15 +25,16 @@ func TestSshKeyResource(t *testing.T) {
 			// Create and Read testing
 			{
 				Config: providerConfig + `
+
 resource "binarylane_ssh_key" "test" {
-	name       = "tf-test-key-resource-test"
-	public_key = "` + publicKey + `"
+  name       = "tf-test-key-resource-test"
+  public_key = "` + publicKey + `"
 }
 
 data "binarylane_ssh_key" "test" {
   depends_on = [binarylane_ssh_key.test]
 
-	id = binarylane_ssh_key.test.id
+  id = binarylane_ssh_key.test.id
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/provider/vpc_resource_test.go
+++ b/internal/provider/vpc_resource_test.go
@@ -14,30 +14,31 @@ func TestVpcResource(t *testing.T) {
 			// Create and Read testing
 			{
 				Config: providerConfig + `
+
 resource "binarylane_vpc" "test" {
-	name     = "tf-test-vpc"
-	ip_range = "10.240.0.0/16"
+  name     = "tf-test-vpc"
+  ip_range = "10.240.0.0/16"
 }
 
 data "binarylane_vpc" "test" {
   depends_on = [binarylane_vpc.test]
 
-	id = binarylane_vpc.test.id
+  id = binarylane_vpc.test.id
 }
 
 resource "binarylane_vpc_route_entries" "test" {
-	vpc_id = binarylane_vpc.test.id
-	route_entries = [
-		{
-			description = "test"
-			destination = "0.0.0.0/0"
-			router      = "10.240.0.1"
-		}
-	]
+  vpc_id = binarylane_vpc.test.id
+  route_entries = [
+    {
+      description = "test"
+      destination = "0.0.0.0/0"
+      router      = "10.240.0.1"
+    }
+  ]
 }
 
 data "binarylane_vpc_route_entries" "test" {
-	vpc_id = binarylane_vpc_route_entries.test.vpc_id
+  vpc_id = binarylane_vpc_route_entries.test.vpc_id
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -82,21 +83,23 @@ data "binarylane_vpc_route_entries" "test" {
 			// Update and Read testing
 			{
 				Config: providerConfig + `
+
 resource "binarylane_vpc" "test" {
-	name     = "tf-test-vpc-renamed"
-	ip_range = "10.240.0.0/16"
+  name     = "tf-test-vpc-renamed"
+  ip_range = "10.240.0.0/16"
 }
 
 resource "binarylane_vpc_route_entries" "test" {
-	vpc_id = binarylane_vpc.test.id
-	route_entries = [
-		{
-			description = "test-renamed"
-			destination = "0.0.0.0/0"
-			router      = "10.240.0.2"
-		}
-	]
-}`,
+  vpc_id = binarylane_vpc.test.id
+  route_entries = [
+    {
+      description = "test-renamed"
+      destination = "0.0.0.0/0"
+      router      = "10.240.0.2"
+    }
+  ]
+}
+`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify binarylane_vpc resource values updated
 					resource.TestCheckResourceAttr("binarylane_vpc.test", "name", "tf-test-vpc-renamed"), // Updated name


### PR DESCRIPTION
Partial progress towards https://github.com/oscarhermoso/terraform-provider-binarylane/issues/30 - see rationale in the issue description.