### PR TITLE
🔧 rebuild server when `ssh_keys`, `image` or `user_data` changes

### DIFF
--- a/internal/binarylane/client.go
+++ b/internal/binarylane/client.go
@@ -6,17 +6,32 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httputil"
+	"os"
 
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func NewClientWithAuth(endpoint string, token string) (*ClientWithResponses, error) {
+func NewClientWithDefaultConfig() (*ClientWithResponses, error) {
+	return NewClientWithConfig("", "")
+}
+
+func NewClientWithConfig(endpoint string, token string) (*ClientWithResponses, error) {
+	if endpoint == "" {
+		endpoint = os.Getenv("BINARYLANE_API_ENDPOINT")
+		if endpoint == "" {
+			endpoint = "https://api.binarylane.com.au/v2"
+		}
+	}
+
 	if token == "" {
-		return nil, errors.New("missing or empty value for the Binary Lane API " +
-			"token. Set the `api_token` value in the configuration or use the " +
-			"BINARYLANE_API_TOKEN environment variable. If either is already set, " +
-			"ensure the value is not empty")
+		token = os.Getenv("BINARYLANE_API_TOKEN")
+		if token == "" {
+			return nil, errors.New("missing or empty value for the Binary Lane API " +
+				"token. Set the `api_token` value in the configuration or use the " +
+				"BINARYLANE_API_TOKEN environment variable. If either is already set, " +
+				"ensure the value is not empty")
+		}
 	}
 
 	auth, err := securityprovider.NewSecurityProviderBearerToken(token)

--- a/internal/binarylane/fetch-openapi.sh
+++ b/internal/binarylane/fetch-openapi.sh
@@ -12,6 +12,9 @@ cat <<<$(jq '.paths |= with_entries(.key |= sub("/v2/"; "/"))' $OPENAPI_FILE) >$
 # Terraform can't handle oneOf types, so we need to replace them with basic types
 cat <<<$(jq '.components.schemas.CreateServerRequest.properties.image |= del(.oneOf) + {type:"string"}' $OPENAPI_FILE) >$OPENAPI_FILE
 cat <<<$(jq '.components.schemas.CreateServerRequest.properties.ssh_keys.items |= del(.oneOf) + {type:"integer"}' $OPENAPI_FILE) >$OPENAPI_FILE
+cat <<<$(jq '.components.schemas.Rebuild.properties.image |= del(.oneOf) + {type:"string"}' $OPENAPI_FILE) >$OPENAPI_FILE
+cat <<<$(jq '.components.schemas.ImageOptions.properties.ssh_keys.items |= del(.oneOf) + {type:"integer"}' $OPENAPI_FILE) >$OPENAPI_FILE
+cat <<<$(jq '.components.schemas.ChangeImage.properties.image |= del(.oneOf) + {type:"string"}' $OPENAPI_FILE) >$OPENAPI_FILE
 cat <<<$(jq '.paths["/account/keys/{key_id}"].delete.parameters[0].schema |= del(.oneOf) + {type:"integer"}' $OPENAPI_FILE) >$OPENAPI_FILE
 cat <<<$(jq '.paths["/account/keys/{key_id}"].put.parameters[0].schema |= del(.oneOf) + {type:"integer"}' $OPENAPI_FILE) >$OPENAPI_FILE
 cat <<<$(jq '.paths["/account/keys/{key_id}"].get.parameters[0].schema |= del(.oneOf) + {type:"integer"}' $OPENAPI_FILE) >$OPENAPI_FILE

--- a/internal/binarylane/openapi.json
+++ b/internal/binarylane/openapi.json
@@ -9514,17 +9514,10 @@
         "type": "object",
         "properties": {
           "image": {
-            "oneOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "string"
-              }
-            ],
             "description": "The slug or ID of the selected image. What type of image is permitted here varies based on the server action.",
             "nullable": true,
-            "example": 5
+            "example": 5,
+            "type": "string"
           },
           "options": {
             "allOf": [
@@ -11306,15 +11299,8 @@
           "ssh_keys": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string"
-                }
-              ],
-              "example": 5
+              "example": 5,
+              "type": "integer"
             },
             "description": "This may be either the existing SSH Keys IDs or fingerprints.\nIf this is null or not provided any SSH keys that have been marked as default will be deployed (if the operating system supports SSH Keys).\nSubmit an empty array to disable deployment of default keys.",
             "nullable": true
@@ -12491,17 +12477,10 @@
             "type": "string"
           },
           "image": {
-            "oneOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "string"
-              }
-            ],
             "description": "The Operating System ID or slug or Backup image ID to use as a base for the rebuild.",
             "nullable": true,
-            "example": 5
+            "example": 5,
+            "type": "string"
           },
           "options": {
             "allOf": [

--- a/internal/binarylane/types_gen.go
+++ b/internal/binarylane/types_gen.go
@@ -854,21 +854,10 @@ type ChangeBackupScheduleType string
 // ChangeImage defines model for ChangeImage.
 type ChangeImage struct {
 	// Image The slug or ID of the selected image. What type of image is permitted here varies based on the server action.
-	Image *ChangeImage_Image `json:"image"`
+	Image *string `json:"image"`
 
 	// Options Additional options for the server configuration after the image has been changed.
 	Options *ImageOptions `json:"options"`
-}
-
-// ChangeImageImage0 defines model for .
-type ChangeImageImage0 = int
-
-// ChangeImageImage1 defines model for .
-type ChangeImageImage1 = string
-
-// ChangeImage_Image The slug or ID of the selected image. What type of image is permitted here varies based on the server action.
-type ChangeImage_Image struct {
-	union json.RawMessage
 }
 
 // ChangeIpv6 Enable or Disable IPv6 for a Server
@@ -1662,21 +1651,10 @@ type ImageOptions struct {
 	// SshKeys This may be either the existing SSH Keys IDs or fingerprints.
 	// If this is null or not provided any SSH keys that have been marked as default will be deployed (if the operating system supports SSH Keys).
 	// Submit an empty array to disable deployment of default keys.
-	SshKeys *[]ImageOptions_SshKeys_Item `json:"ssh_keys"`
+	SshKeys *[]int `json:"ssh_keys"`
 
 	// UserData If provided this will be used to initialise the new server. This must be left null if the Image does not support UserData, see DistributionInfo.Features for more information.
 	UserData *string `json:"user_data"`
-}
-
-// ImageOptionsSshKeys0 defines model for .
-type ImageOptionsSshKeys0 = int
-
-// ImageOptionsSshKeys1 defines model for .
-type ImageOptionsSshKeys1 = string
-
-// ImageOptions_SshKeys_Item defines model for ImageOptions.ssh_keys.Item.
-type ImageOptions_SshKeys_Item struct {
-	union json.RawMessage
 }
 
 // ImageQueryType
@@ -2176,22 +2154,11 @@ type RebootType string
 // Rebuild Rebuild an Existing Server
 type Rebuild struct {
 	// Image The Operating System ID or slug or Backup image ID to use as a base for the rebuild.
-	Image *Rebuild_Image `json:"image"`
+	Image *string `json:"image"`
 
 	// Options Additional options. Leaving this entirely null or any of the properties included null will use the defaults from the existing server.
 	Options *ImageOptions `json:"options"`
 	Type    RebuildType   `json:"type"`
-}
-
-// RebuildImage0 defines model for .
-type RebuildImage0 = int
-
-// RebuildImage1 defines model for .
-type RebuildImage1 = string
-
-// Rebuild_Image The Operating System ID or slug or Backup image ID to use as a base for the rebuild.
-type Rebuild_Image struct {
-	union json.RawMessage
 }
 
 // RebuildType defines model for Rebuild.Type.
@@ -3985,130 +3952,6 @@ func (a ValidationProblemDetails) MarshalJSON() ([]byte, error) {
 	return json.Marshal(object)
 }
 
-// AsChangeImageImage0 returns the union data inside the ChangeImage_Image as a ChangeImageImage0
-func (t ChangeImage_Image) AsChangeImageImage0() (ChangeImageImage0, error) {
-	var body ChangeImageImage0
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromChangeImageImage0 overwrites any union data inside the ChangeImage_Image as the provided ChangeImageImage0
-func (t *ChangeImage_Image) FromChangeImageImage0(v ChangeImageImage0) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeChangeImageImage0 performs a merge with any union data inside the ChangeImage_Image, using the provided ChangeImageImage0
-func (t *ChangeImage_Image) MergeChangeImageImage0(v ChangeImageImage0) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-// AsChangeImageImage1 returns the union data inside the ChangeImage_Image as a ChangeImageImage1
-func (t ChangeImage_Image) AsChangeImageImage1() (ChangeImageImage1, error) {
-	var body ChangeImageImage1
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromChangeImageImage1 overwrites any union data inside the ChangeImage_Image as the provided ChangeImageImage1
-func (t *ChangeImage_Image) FromChangeImageImage1(v ChangeImageImage1) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeChangeImageImage1 performs a merge with any union data inside the ChangeImage_Image, using the provided ChangeImageImage1
-func (t *ChangeImage_Image) MergeChangeImageImage1(v ChangeImageImage1) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-func (t ChangeImage_Image) MarshalJSON() ([]byte, error) {
-	b, err := t.union.MarshalJSON()
-	return b, err
-}
-
-func (t *ChangeImage_Image) UnmarshalJSON(b []byte) error {
-	err := t.union.UnmarshalJSON(b)
-	return err
-}
-
-// AsImageOptionsSshKeys0 returns the union data inside the ImageOptions_SshKeys_Item as a ImageOptionsSshKeys0
-func (t ImageOptions_SshKeys_Item) AsImageOptionsSshKeys0() (ImageOptionsSshKeys0, error) {
-	var body ImageOptionsSshKeys0
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromImageOptionsSshKeys0 overwrites any union data inside the ImageOptions_SshKeys_Item as the provided ImageOptionsSshKeys0
-func (t *ImageOptions_SshKeys_Item) FromImageOptionsSshKeys0(v ImageOptionsSshKeys0) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeImageOptionsSshKeys0 performs a merge with any union data inside the ImageOptions_SshKeys_Item, using the provided ImageOptionsSshKeys0
-func (t *ImageOptions_SshKeys_Item) MergeImageOptionsSshKeys0(v ImageOptionsSshKeys0) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-// AsImageOptionsSshKeys1 returns the union data inside the ImageOptions_SshKeys_Item as a ImageOptionsSshKeys1
-func (t ImageOptions_SshKeys_Item) AsImageOptionsSshKeys1() (ImageOptionsSshKeys1, error) {
-	var body ImageOptionsSshKeys1
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromImageOptionsSshKeys1 overwrites any union data inside the ImageOptions_SshKeys_Item as the provided ImageOptionsSshKeys1
-func (t *ImageOptions_SshKeys_Item) FromImageOptionsSshKeys1(v ImageOptionsSshKeys1) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeImageOptionsSshKeys1 performs a merge with any union data inside the ImageOptions_SshKeys_Item, using the provided ImageOptionsSshKeys1
-func (t *ImageOptions_SshKeys_Item) MergeImageOptionsSshKeys1(v ImageOptionsSshKeys1) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-func (t ImageOptions_SshKeys_Item) MarshalJSON() ([]byte, error) {
-	b, err := t.union.MarshalJSON()
-	return b, err
-}
-
-func (t *ImageOptions_SshKeys_Item) UnmarshalJSON(b []byte) error {
-	err := t.union.UnmarshalJSON(b)
-	return err
-}
-
 // AsNetworkNetmask0 returns the union data inside the Network_Netmask as a NetworkNetmask0
 func (t Network_Netmask) AsNetworkNetmask0() (NetworkNetmask0, error) {
 	var body NetworkNetmask0
@@ -4167,68 +4010,6 @@ func (t Network_Netmask) MarshalJSON() ([]byte, error) {
 }
 
 func (t *Network_Netmask) UnmarshalJSON(b []byte) error {
-	err := t.union.UnmarshalJSON(b)
-	return err
-}
-
-// AsRebuildImage0 returns the union data inside the Rebuild_Image as a RebuildImage0
-func (t Rebuild_Image) AsRebuildImage0() (RebuildImage0, error) {
-	var body RebuildImage0
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromRebuildImage0 overwrites any union data inside the Rebuild_Image as the provided RebuildImage0
-func (t *Rebuild_Image) FromRebuildImage0(v RebuildImage0) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeRebuildImage0 performs a merge with any union data inside the Rebuild_Image, using the provided RebuildImage0
-func (t *Rebuild_Image) MergeRebuildImage0(v RebuildImage0) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-// AsRebuildImage1 returns the union data inside the Rebuild_Image as a RebuildImage1
-func (t Rebuild_Image) AsRebuildImage1() (RebuildImage1, error) {
-	var body RebuildImage1
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromRebuildImage1 overwrites any union data inside the Rebuild_Image as the provided RebuildImage1
-func (t *Rebuild_Image) FromRebuildImage1(v RebuildImage1) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeRebuildImage1 performs a merge with any union data inside the Rebuild_Image, using the provided RebuildImage1
-func (t *Rebuild_Image) MergeRebuildImage1(v RebuildImage1) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-func (t Rebuild_Image) MarshalJSON() ([]byte, error) {
-	b, err := t.union.MarshalJSON()
-	return b, err
-}
-
-func (t *Rebuild_Image) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"os"
 	"terraform-provider-binarylane/internal/binarylane"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -23,8 +22,7 @@ func New(version string) func() provider.Provider {
 }
 
 type BinarylaneClient struct {
-	endpoint string
-	client   *binarylane.ClientWithResponses
+	client *binarylane.ClientWithResponses
 }
 
 type binarylaneProvider struct {
@@ -65,32 +63,17 @@ func (p *binarylaneProvider) Configure(ctx context.Context, req provider.Configu
 		return
 	}
 
-	endpoint := config.Endpoint.ValueString()
-	if endpoint == "" {
-		endpoint = os.Getenv("BINARYLANE_API_ENDPOINT")
-		if endpoint == "" {
-			endpoint = "https://api.binarylane.com.au/v2"
-		}
-	}
-
-	token := config.Token.ValueString()
-	if token == "" {
-		token = os.Getenv("BINARYLANE_API_TOKEN")
-	}
-
-	client, err := binarylane.NewClientWithAuth(
-		endpoint,
-		token,
+	client, err := binarylane.NewClientWithConfig(
+		config.Endpoint.ValueString(),
+		config.Token.ValueString(),
 	)
-
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create Binary Lane API client", err.Error())
 		return
 	}
 
 	binarylaneClient := BinarylaneClient{
-		endpoint: endpoint,
-		client:   client,
+		client: client,
 	}
 
 	resp.DataSourceData = binarylaneClient

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"slices"
 
@@ -152,4 +153,27 @@ func convertResourceSchemaToDataSourceSchema(rs r_schema.Schema, cfg AttributeCo
 	}
 
 	return &ds, nil
+}
+
+func listContainsUnknown(ctx context.Context, list types.List) bool {
+	// If the whole list is unknown, return true
+	if list.IsUnknown() {
+		return true
+	}
+
+	// Get elements as generic attr.Value to check individual unknown status
+	var elements []attr.Value
+	diags := list.ElementsAs(ctx, &elements, false)
+	if diags.HasError() {
+		return true // Assume unknown in case of errors
+	}
+
+	// Check if any element is unknown
+	for _, elem := range elements {
+		if elem.IsUnknown() {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
More progress on https://github.com/oscarhermoso/terraform-provider-binarylane/issues/37

* When `ssh_keys`, `image` or `user_data` is updated, the server will be rebuilt of being completely destroyed & recreated. The main advantage of this is preserving IP addresses assigned to the server.
* Fix plans for changes to `public_ipv4_count`
* Created a test sweeper for any lingering VPC resources