### PR TITLE
🧁 allow update of server `vpc_id` without recreating resource, bump api

### DIFF
--- a/internal/binarylane/client_gen.go
+++ b/internal/binarylane/client_gen.go
@@ -197,17 +197,6 @@ type ClientInterface interface {
 		union json.RawMessage
 	}, recordId int64, body PutDomainsDomainNameRecordsRecordIdJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetFailoverIpsServerId request
-	GetFailoverIpsServerId(ctx context.Context, serverId int64, params *GetFailoverIpsServerIdParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// PostFailoverIpsServerIdWithBody request with any body
-	PostFailoverIpsServerIdWithBody(ctx context.Context, serverId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	PostFailoverIpsServerId(ctx context.Context, serverId int64, body PostFailoverIpsServerIdJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// GetFailoverIpsServerIdAvailable request
-	GetFailoverIpsServerIdAvailable(ctx context.Context, serverId int64, params *GetFailoverIpsServerIdAvailableParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// GetImages request
 	GetImages(ctx context.Context, params *GetImagesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -977,54 +966,6 @@ func (c *Client) PutDomainsDomainNameRecordsRecordId(ctx context.Context, domain
 	union json.RawMessage
 }, recordId int64, body PutDomainsDomainNameRecordsRecordIdJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPutDomainsDomainNameRecordsRecordIdRequest(c.Server, domainName, recordId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) GetFailoverIpsServerId(ctx context.Context, serverId int64, params *GetFailoverIpsServerIdParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetFailoverIpsServerIdRequest(c.Server, serverId, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) PostFailoverIpsServerIdWithBody(ctx context.Context, serverId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostFailoverIpsServerIdRequestWithBody(c.Server, serverId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) PostFailoverIpsServerId(ctx context.Context, serverId int64, body PostFailoverIpsServerIdJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostFailoverIpsServerIdRequest(c.Server, serverId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) GetFailoverIpsServerIdAvailable(ctx context.Context, serverId int64, params *GetFailoverIpsServerIdAvailableParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetFailoverIpsServerIdAvailableRequest(c.Server, serverId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3916,197 +3857,6 @@ func NewPutDomainsDomainNameRecordsRecordIdRequestWithBody(server string, domain
 	}
 
 	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
-// NewGetFailoverIpsServerIdRequest generates requests for GetFailoverIpsServerId
-func NewGetFailoverIpsServerIdRequest(server string, serverId int64, params *GetFailoverIpsServerIdParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "server_id", runtime.ParamLocationPath, serverId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/failover_ips/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.Page != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.PerPage != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "per_page", runtime.ParamLocationQuery, *params.PerPage); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewPostFailoverIpsServerIdRequest calls the generic PostFailoverIpsServerId builder with application/json body
-func NewPostFailoverIpsServerIdRequest(server string, serverId int64, body PostFailoverIpsServerIdJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewPostFailoverIpsServerIdRequestWithBody(server, serverId, "application/json", bodyReader)
-}
-
-// NewPostFailoverIpsServerIdRequestWithBody generates requests for PostFailoverIpsServerId with any type of body
-func NewPostFailoverIpsServerIdRequestWithBody(server string, serverId int64, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "server_id", runtime.ParamLocationPath, serverId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/failover_ips/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
-// NewGetFailoverIpsServerIdAvailableRequest generates requests for GetFailoverIpsServerIdAvailable
-func NewGetFailoverIpsServerIdAvailableRequest(server string, serverId int64, params *GetFailoverIpsServerIdAvailableParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "server_id", runtime.ParamLocationPath, serverId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/failover_ips/%s/available", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.Page != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.PerPage != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "per_page", runtime.ParamLocationQuery, *params.PerPage); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
 
 	return req, nil
 }
@@ -8665,17 +8415,6 @@ type ClientWithResponsesInterface interface {
 		union json.RawMessage
 	}, recordId int64, body PutDomainsDomainNameRecordsRecordIdJSONRequestBody, reqEditors ...RequestEditorFn) (*PutDomainsDomainNameRecordsRecordIdResponse, error)
 
-	// GetFailoverIpsServerIdWithResponse request
-	GetFailoverIpsServerIdWithResponse(ctx context.Context, serverId int64, params *GetFailoverIpsServerIdParams, reqEditors ...RequestEditorFn) (*GetFailoverIpsServerIdResponse, error)
-
-	// PostFailoverIpsServerIdWithBodyWithResponse request with any body
-	PostFailoverIpsServerIdWithBodyWithResponse(ctx context.Context, serverId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostFailoverIpsServerIdResponse, error)
-
-	PostFailoverIpsServerIdWithResponse(ctx context.Context, serverId int64, body PostFailoverIpsServerIdJSONRequestBody, reqEditors ...RequestEditorFn) (*PostFailoverIpsServerIdResponse, error)
-
-	// GetFailoverIpsServerIdAvailableWithResponse request
-	GetFailoverIpsServerIdAvailableWithResponse(ctx context.Context, serverId int64, params *GetFailoverIpsServerIdAvailableParams, reqEditors ...RequestEditorFn) (*GetFailoverIpsServerIdAvailableResponse, error)
-
 	// GetImagesWithResponse request
 	GetImagesWithResponse(ctx context.Context, params *GetImagesParams, reqEditors ...RequestEditorFn) (*GetImagesResponse, error)
 
@@ -9641,76 +9380,6 @@ func (r PutDomainsDomainNameRecordsRecordIdResponse) StatusCode() int {
 	return 0
 }
 
-type GetFailoverIpsServerIdResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *FailoverIpsResponse
-	JSON404      *ProblemDetails
-}
-
-// Status returns HTTPResponse.Status
-func (r GetFailoverIpsServerIdResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetFailoverIpsServerIdResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type PostFailoverIpsServerIdResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *ActionResponse
-	JSON400      *ValidationProblemDetails
-	JSON404      *ProblemDetails
-}
-
-// Status returns HTTPResponse.Status
-func (r PostFailoverIpsServerIdResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r PostFailoverIpsServerIdResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type GetFailoverIpsServerIdAvailableResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *FailoverIpsResponse
-	JSON404      *ProblemDetails
-}
-
-// Status returns HTTPResponse.Status
-func (r GetFailoverIpsServerIdAvailableResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetFailoverIpsServerIdAvailableResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
 type GetImagesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -9761,6 +9430,7 @@ type GetImagesImageIdDownloadResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *ImageDownloadResponse
+	JSON400      *ValidationProblemDetails
 	JSON404      *ProblemDetails
 }
 
@@ -12123,41 +11793,6 @@ func (c *ClientWithResponses) PutDomainsDomainNameRecordsRecordIdWithResponse(ct
 	return ParsePutDomainsDomainNameRecordsRecordIdResponse(rsp)
 }
 
-// GetFailoverIpsServerIdWithResponse request returning *GetFailoverIpsServerIdResponse
-func (c *ClientWithResponses) GetFailoverIpsServerIdWithResponse(ctx context.Context, serverId int64, params *GetFailoverIpsServerIdParams, reqEditors ...RequestEditorFn) (*GetFailoverIpsServerIdResponse, error) {
-	rsp, err := c.GetFailoverIpsServerId(ctx, serverId, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetFailoverIpsServerIdResponse(rsp)
-}
-
-// PostFailoverIpsServerIdWithBodyWithResponse request with arbitrary body returning *PostFailoverIpsServerIdResponse
-func (c *ClientWithResponses) PostFailoverIpsServerIdWithBodyWithResponse(ctx context.Context, serverId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostFailoverIpsServerIdResponse, error) {
-	rsp, err := c.PostFailoverIpsServerIdWithBody(ctx, serverId, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParsePostFailoverIpsServerIdResponse(rsp)
-}
-
-func (c *ClientWithResponses) PostFailoverIpsServerIdWithResponse(ctx context.Context, serverId int64, body PostFailoverIpsServerIdJSONRequestBody, reqEditors ...RequestEditorFn) (*PostFailoverIpsServerIdResponse, error) {
-	rsp, err := c.PostFailoverIpsServerId(ctx, serverId, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParsePostFailoverIpsServerIdResponse(rsp)
-}
-
-// GetFailoverIpsServerIdAvailableWithResponse request returning *GetFailoverIpsServerIdAvailableResponse
-func (c *ClientWithResponses) GetFailoverIpsServerIdAvailableWithResponse(ctx context.Context, serverId int64, params *GetFailoverIpsServerIdAvailableParams, reqEditors ...RequestEditorFn) (*GetFailoverIpsServerIdAvailableResponse, error) {
-	rsp, err := c.GetFailoverIpsServerIdAvailable(ctx, serverId, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetFailoverIpsServerIdAvailableResponse(rsp)
-}
-
 // GetImagesWithResponse request returning *GetImagesResponse
 func (c *ClientWithResponses) GetImagesWithResponse(ctx context.Context, params *GetImagesParams, reqEditors ...RequestEditorFn) (*GetImagesResponse, error) {
 	rsp, err := c.GetImages(ctx, params, reqEditors...)
@@ -14171,112 +13806,6 @@ func ParsePutDomainsDomainNameRecordsRecordIdResponse(rsp *http.Response) (*PutD
 	return response, nil
 }
 
-// ParseGetFailoverIpsServerIdResponse parses an HTTP response from a GetFailoverIpsServerIdWithResponse call
-func ParseGetFailoverIpsServerIdResponse(rsp *http.Response) (*GetFailoverIpsServerIdResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetFailoverIpsServerIdResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest FailoverIpsResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest ProblemDetails
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParsePostFailoverIpsServerIdResponse parses an HTTP response from a PostFailoverIpsServerIdWithResponse call
-func ParsePostFailoverIpsServerIdResponse(rsp *http.Response) (*PostFailoverIpsServerIdResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &PostFailoverIpsServerIdResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ActionResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
-		var dest ValidationProblemDetails
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON400 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest ProblemDetails
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseGetFailoverIpsServerIdAvailableResponse parses an HTTP response from a GetFailoverIpsServerIdAvailableWithResponse call
-func ParseGetFailoverIpsServerIdAvailableResponse(rsp *http.Response) (*GetFailoverIpsServerIdAvailableResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetFailoverIpsServerIdAvailableResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest FailoverIpsResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest ProblemDetails
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseGetImagesResponse parses an HTTP response from a GetImagesWithResponse call
 func ParseGetImagesResponse(rsp *http.Response) (*GetImagesResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -14363,6 +13892,13 @@ func ParseGetImagesImageIdDownloadResponse(rsp *http.Response) (*GetImagesImageI
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ValidationProblemDetails
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
 		var dest ProblemDetails

--- a/internal/binarylane/openapi.json
+++ b/internal/binarylane/openapi.json
@@ -8,7 +8,7 @@
       "url": "https://support.binarylane.com.au",
       "email": "support@binarylane.com.au"
     },
-    "version": "0.25.0",
+    "version": "0.26.0",
     "x-logo": {
       "url": "https://www.binarylane.com.au/res/images/binarylane/logo.png",
       "backgroundColor": "#000000",
@@ -1200,242 +1200,6 @@
         "x-cli-command": "domain record delete"
       }
     },
-    "/failover_ips/{server_id}": {
-      "get": {
-        "tags": [
-          "FailoverIps"
-        ],
-        "summary": "Fetch the Failover IPs for a Server",
-        "parameters": [
-          {
-            "name": "server_id",
-            "in": "path",
-            "description": "The target server id.",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "description": "The target server id.",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "The selected page. Page numbering starts at 1",
-            "schema": {
-              "maximum": 2147483647,
-              "minimum": 1,
-              "type": "integer",
-              "description": "The selected page. Page numbering starts at 1",
-              "format": "int32",
-              "default": 1
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "The number of results to show per page.",
-            "schema": {
-              "maximum": 200,
-              "minimum": 1,
-              "type": "integer",
-              "description": "The number of results to show per page.",
-              "format": "int32",
-              "default": 20
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FailoverIpsResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "Curl",
-            "source": "curl -X GET \"https://api.binarylane.com.au/v2/failover_ips/${server_id}?page=${page}&per_page=${per_page}\"  \\\n-H \"Authorization: Bearer ${APITOKEN}\""
-          }
-        ],
-        "x-cli-command": "server failover-ip get"
-      },
-      "post": {
-        "tags": [
-          "FailoverIps"
-        ],
-        "summary": "Sets the List of Failover IPs that are Assigned to a Server",
-        "description": "This overwrites the current list, i.e. submit the entire list, not just updates.\nIf NoContent is returned no changes were made.\nIf an action is returned the changes have been saved but the effect may not be complete until the action is complete. If the action does not complete the network changes can be forced by rebooting the server.",
-        "parameters": [
-          {
-            "name": "server_id",
-            "in": "path",
-            "description": "The target server id.",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "description": "The target server id.",
-              "format": "int64"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/FailoverIpsRequest"
-                  }
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResponse"
-                }
-              }
-            }
-          },
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "Curl",
-            "source": "curl -X POST \"https://api.binarylane.com.au/v2/failover_ips/${server_id}\"  \\\n-H \"Authorization: Bearer ${APITOKEN}\"  \\\n-H \"Content-Type: application/json\" -d \"${PAYLOAD}\""
-          }
-        ],
-        "x-cli-command": "server failover-ip update"
-      }
-    },
-    "/failover_ips/{server_id}/available": {
-      "get": {
-        "tags": [
-          "FailoverIps"
-        ],
-        "summary": "Fetch a List of all Failover IPs that are Available to be Assigned to a Server",
-        "parameters": [
-          {
-            "name": "server_id",
-            "in": "path",
-            "description": "The target server id.",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "description": "The target server id.",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "The selected page. Page numbering starts at 1",
-            "schema": {
-              "maximum": 2147483647,
-              "minimum": 1,
-              "type": "integer",
-              "description": "The selected page. Page numbering starts at 1",
-              "format": "int32",
-              "default": 1
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "The number of results to show per page.",
-            "schema": {
-              "maximum": 200,
-              "minimum": 1,
-              "type": "integer",
-              "description": "The number of results to show per page.",
-              "format": "int32",
-              "default": 20
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FailoverIpsResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "Curl",
-            "source": "curl -X GET \"https://api.binarylane.com.au/v2/failover_ips/${server_id}/available?page=${page}&per_page=${per_page}\"  \\\n-H \"Authorization: Bearer ${APITOKEN}\""
-          }
-        ],
-        "x-cli-command": "server failover-ip available"
-      }
-    },
     "/images": {
       "get": {
         "tags": [
@@ -1609,6 +1373,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImageDownloadResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
                 }
               }
             }
@@ -9199,7 +8973,7 @@
           },
           "iso": {
             "type": "boolean",
-            "description": "If this is true the backup is an ISO image and cannot be restored. ISO images may only be attached for use as a boot disk or an additional disk.",
+            "description": "If this is true the backup is an ISO image and cannot be restored or downloaded. ISO images may only be attached for use as a boot disk or an additional disk.",
             "readOnly": true
           },
           "backup_disks": {
@@ -10934,53 +10708,6 @@
           }
         },
         "description": "Enable IPv6 for a Server"
-      },
-      "FailoverIpsRequest": {
-        "required": [
-          "failover_ips"
-        ],
-        "type": "object",
-        "properties": {
-          "failover_ips": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "The list of IP Failover addresses to assign to this server. This overwrites the current list, so any current IP Failover addresses that are omitted will be removed from the server."
-          }
-        }
-      },
-      "FailoverIpsResponse": {
-        "required": [
-          "failover_ips",
-          "meta"
-        ],
-        "type": "object",
-        "properties": {
-          "meta": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Meta"
-              }
-            ],
-            "description": "Contains metadata about the response, currently this includes the total number of items."
-          },
-          "links": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Links"
-              }
-            ],
-            "nullable": true
-          },
-          "failover_ips": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "readOnly": true
-          }
-        }
       },
       "ForwardingRule": {
         "required": [
@@ -15008,7 +14735,6 @@
         "ServerActions",
         "Actions",
         "DataUsages",
-        "FailoverIps",
         "Images",
         "Keys",
         "ReverseNames",

--- a/internal/binarylane/types_gen.go
+++ b/internal/binarylane/types_gen.go
@@ -714,7 +714,7 @@ type BackupInfo struct {
 	// BackupDisks A list of the individual disks that make up this backup.
 	BackupDisks *[]BackupDisk `json:"backup_disks,omitempty"`
 
-	// Iso If this is true the backup is an ISO image and cannot be restored. ISO images may only be attached for use as a boot disk or an additional disk.
+	// Iso If this is true the backup is an ISO image and cannot be restored or downloaded. ISO images may only be attached for use as a boot disk or an additional disk.
 	Iso *bool `json:"iso,omitempty"`
 
 	// Locked If this is true the backup is locked and cannot be replaced.
@@ -1501,21 +1501,6 @@ type EnableIpv6 struct {
 
 // EnableIpv6Type defines model for EnableIpv6.Type.
 type EnableIpv6Type string
-
-// FailoverIpsRequest defines model for FailoverIpsRequest.
-type FailoverIpsRequest struct {
-	// FailoverIps The list of IP Failover addresses to assign to this server. This overwrites the current list, so any current IP Failover addresses that are omitted will be removed from the server.
-	FailoverIps []string `json:"failover_ips"`
-}
-
-// FailoverIpsResponse defines model for FailoverIpsResponse.
-type FailoverIpsResponse struct {
-	FailoverIps *[]string `json:"failover_ips,omitempty"`
-	Links       *Links    `json:"links"`
-
-	// Meta Contains metadata about the response, currently this includes the total number of items.
-	Meta Meta `json:"meta"`
-}
 
 // ForwardingRule defines model for ForwardingRule.
 type ForwardingRule struct {
@@ -3214,27 +3199,6 @@ type PutDomainsDomainNameRecordsRecordIdParamsDomainName0 = int
 // PutDomainsDomainNameRecordsRecordIdParamsDomainName1 defines parameters for PutDomainsDomainNameRecordsRecordId.
 type PutDomainsDomainNameRecordsRecordIdParamsDomainName1 = string
 
-// GetFailoverIpsServerIdParams defines parameters for GetFailoverIpsServerId.
-type GetFailoverIpsServerIdParams struct {
-	// Page The selected page. Page numbering starts at 1
-	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
-
-	// PerPage The number of results to show per page.
-	PerPage *int32 `form:"per_page,omitempty" json:"per_page,omitempty"`
-}
-
-// PostFailoverIpsServerIdJSONBody defines parameters for PostFailoverIpsServerId.
-type PostFailoverIpsServerIdJSONBody = FailoverIpsRequest
-
-// GetFailoverIpsServerIdAvailableParams defines parameters for GetFailoverIpsServerIdAvailable.
-type GetFailoverIpsServerIdAvailableParams struct {
-	// Page The selected page. Page numbering starts at 1
-	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
-
-	// PerPage The number of results to show per page.
-	PerPage *int32 `form:"per_page,omitempty" json:"per_page,omitempty"`
-}
-
 // GetImagesParams defines parameters for GetImages.
 type GetImagesParams struct {
 	// Type Queries for distribution will include images that have pre-installed applications.
@@ -3521,9 +3485,6 @@ type PostDomainsDomainNameRecordsJSONRequestBody = PostDomainsDomainNameRecordsJ
 
 // PutDomainsDomainNameRecordsRecordIdJSONRequestBody defines body for PutDomainsDomainNameRecordsRecordId for application/json ContentType.
 type PutDomainsDomainNameRecordsRecordIdJSONRequestBody = PutDomainsDomainNameRecordsRecordIdJSONBody
-
-// PostFailoverIpsServerIdJSONRequestBody defines body for PostFailoverIpsServerId for application/json ContentType.
-type PostFailoverIpsServerIdJSONRequestBody = PostFailoverIpsServerIdJSONBody
 
 // PostLoadBalancersJSONRequestBody defines body for PostLoadBalancers for application/json ContentType.
 type PostLoadBalancersJSONRequestBody = PostLoadBalancersJSONBody

--- a/internal/provider/load_balancer_data_source.go
+++ b/internal/provider/load_balancer_data_source.go
@@ -93,7 +93,7 @@ func (d *loadBalancerDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	diags := SetLoadBalancerModelState(ctx, &data.LoadBalancerModel, lbResp.JSON200.LoadBalancer)
+	diags := setLoadBalancerModelState(ctx, &data.LoadBalancerModel, lbResp.JSON200.LoadBalancer)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/load_balancer_resource.go
+++ b/internal/provider/load_balancer_resource.go
@@ -152,7 +152,7 @@ func (r *loadBalancerResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	diags = SetLoadBalancerModelState(ctx, &data.LoadBalancerModel, lbResp.JSON200.LoadBalancer)
+	diags = setLoadBalancerModelState(ctx, &data.LoadBalancerModel, lbResp.JSON200.LoadBalancer)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -245,7 +245,7 @@ func (r *loadBalancerResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	diags := SetLoadBalancerModelState(ctx, &data.LoadBalancerModel, lbResp.JSON200.LoadBalancer)
+	diags := setLoadBalancerModelState(ctx, &data.LoadBalancerModel, lbResp.JSON200.LoadBalancer)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -309,7 +309,7 @@ func (r *loadBalancerResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	diags = SetLoadBalancerModelState(ctx, &data.LoadBalancerModel, lbResp.JSON200.LoadBalancer)
+	diags = setLoadBalancerModelState(ctx, &data.LoadBalancerModel, lbResp.JSON200.LoadBalancer)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -414,7 +414,7 @@ func (r *loadBalancerResource) ImportState(
 	resp.Diagnostics.Append(diags...)
 }
 
-func SetLoadBalancerModelState(ctx context.Context, data *resources.LoadBalancerModel, lb *binarylane.LoadBalancer) diag.Diagnostics {
+func setLoadBalancerModelState(ctx context.Context, data *resources.LoadBalancerModel, lb *binarylane.LoadBalancer) diag.Diagnostics {
 	var diags, diag diag.Diagnostics
 
 	data.Id = types.Int64Value(*lb.Id)

--- a/internal/provider/server_resource_test.go
+++ b/internal/provider/server_resource_test.go
@@ -100,6 +100,7 @@ echo "Hello World" > /var/tmp/output.txt
 					resource.TestCheckResourceAttr("data.binarylane_server.test", "region", "per"),
 					resource.TestCheckResourceAttr("data.binarylane_server.test", "image", "debian-11"),
 					resource.TestCheckResourceAttr("data.binarylane_server.test", "size", "std-min"),
+					resource.TestCheckResourceAttrSet("data.binarylane_server.test", "vpc_id"),
 					resource.TestCheckResourceAttrPair("data.binarylane_server.test", "permalink", "binarylane_server.test", "permalink"),
 					resource.TestCheckResourceAttr("data.binarylane_server.test", "user_data", `#cloud-config
 echo "Hello World" > /var/tmp/output.txt
@@ -147,10 +148,10 @@ resource "binarylane_server" "test" {
   image             = "debian-12"
   size              = "std-1vcpu"
   password          = "` + password + `"
-  vpc_id            = binarylane_vpc.test.id
+  vpc_id            = null
   public_ipv4_count = 0
   ssh_keys          = [binarylane_ssh_key.updated.id]
-	# source_and_destination_check =  true  # defaults to true
+	# source_and_destination_check =  null  # defaults to null when vpc_id is null
   user_data         = <<EOT
 #cloud-config
 echo "Hello Whitespace" > /var/tmp/output.txt
@@ -165,9 +166,10 @@ EOT
 					resource.TestCheckResourceAttr("binarylane_server.test", "public_ipv4_count", "0"),
 					resource.TestCheckResourceAttr("binarylane_server.test", "public_ipv4_addresses.#", "0"),
 					resource.TestCheckResourceAttr("binarylane_server.test", "image", "debian-12"),
+					resource.TestCheckNoResourceAttr("binarylane_server.test", "vpc_id"),
 					resource.TestCheckResourceAttr("binarylane_server.test", "ssh_keys.#", "1"),
 					resource.TestCheckResourceAttrPair("binarylane_server.test", "ssh_keys.0", "binarylane_ssh_key.updated", "id"),
-					resource.TestCheckResourceAttr("binarylane_server.test", "source_and_destination_check", "true"),
+					resource.TestCheckNoResourceAttr("binarylane_server.test", "source_and_destination_check"),
 					resource.TestCheckResourceAttr("binarylane_server.test", "user_data", // test extra whitespace
 						`#cloud-config
 echo "Hello Whitespace" > /var/tmp/output.txt


### PR DESCRIPTION
More progress on https://github.com/oscarhermoso/terraform-provider-binarylane/issues/37 - this PR allows updates to `vpc_id` without needing to recreate the server

It also pulls in the latest v0.26.0 OpenAPI schema